### PR TITLE
Add a view showing jq's error message for invalid filter expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ scroll up and down. Vi keys also work, i.e. you can use `j`/`k` to scroll up or
 down, `g` to move to the top of the view, `G` to jump to the bottom of the
 view, and `Ctrl-F`/`Ctrl-B` to scroll up or down a page at a time.
 
-Use `Ctrl-C` or `Escape` to exit `ijq` immediately, discarding all filters and
-state.
+Use `Ctrl-C` to exit `ijq` immediately, discarding all filters and state.
 
 You can configure the colors by setting the `JQ_COLORS` environment variable.
 See the [jq documentation][colors] for more details.

--- a/ijq.1.scd
+++ b/ijq.1.scd
@@ -66,7 +66,7 @@ up/down by line, Ctrl-F/Ctrl-B to scroll up/down by half page).
 
 Delete all text in the filter field to browse any available history.
 
-The Escape key exits *ijq* immediately, discarding all state.
+Use Ctrl-C to exit *ijq* immediately, discarding all state.
 
 # DEMO
 

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func (d *Document) FromFile(filename string) error {
 func (d *Document) FromStdin() error {
 	if !stdinHasData() {
 		// stdin is not being piped
-		return errors.New("No data on stdin")
+		return errors.New("no data on stdin")
 	}
 
 	var buf bytes.Buffer
@@ -163,6 +163,12 @@ func (d *Document) Filter(filter string) (string, error) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			// jq prints its error message to standard out, but we
+			// will deliver it in the Stderr field as this will
+			// most likely be an exec.ExitError.
+			exiterr.Stderr = out
+		}
 		return "", err
 	}
 
@@ -210,6 +216,15 @@ func readFromFile(filepath string) ([]string, error) {
 	}
 
 	return lines, nil
+}
+
+func stderrFromError(err error) string {
+	exiterr, ok := err.(*exec.ExitError)
+	if ok {
+		return string(exiterr.Stderr)
+	}
+
+	return ""
 }
 
 func parseArgs() (Options, string, []string) {
@@ -283,6 +298,10 @@ func createApp(doc Document, filter string) *tview.Application {
 
 	outputView.SetTitle("Output").SetBorder(true)
 
+	errorView := tview.NewTextView().SetDynamicColors(true)
+	errorView.SetTitle("Error").SetBorder(true)
+
+	errorWriter := tview.ANSIWriter(errorView)
 	outputWriter := tview.ANSIWriter(outputView)
 
 	// If reading the history file fails then just ignore the error and
@@ -297,10 +316,16 @@ func createApp(doc Document, filter string) *tview.Application {
 		SetFieldBackgroundColor(tcell.ColorBlack).
 		SetFieldTextColor(tcell.ColorSilver).
 		SetChangedFunc(func(text string) {
-			go app.QueueUpdate(func() {
+			go app.QueueUpdateDraw(func() {
+				errorView.Clear()
 				out, err := doc.Filter(text)
 				if err != nil {
 					filterInput.SetFieldTextColor(tcell.ColorMaroon)
+					stderr := stderrFromError(err)
+					if stderr != "" {
+						fmt.Fprint(errorWriter, stderr)
+					}
+
 					return
 				}
 
@@ -395,21 +420,23 @@ func createApp(doc Document, filter string) *tview.Application {
 	}()
 
 	grid := tview.NewGrid().
-		SetRows(0, 3).
+		SetRows(0, 3, 4).
 		SetColumns(0).
 		AddItem(tview.NewFlex().
 			AddItem(inputView, 0, 1, false).
 			AddItem(outputView, 0, 1, false), 0, 0, 1, 1, 0, 0, false).
 		AddItem(tview.NewFlex().
 			AddItem(tview.NewBox(), 0, 1, false).
-			AddItem(filterInput, 0, 3, true).
-			AddItem(tview.NewBox(), 0, 1, false), 1, 0, 1, 1, 0, 0, true)
+			AddItem(filterInput, 0, 4, true).
+			AddItem(tview.NewBox(), 0, 1, false), 1, 0, 1, 1, 0, 0, true).
+		AddItem(tview.NewFlex().
+			AddItem(tview.NewBox(), 0, 1, false).
+			AddItem(errorView, 0, 4, false).
+			AddItem(tview.NewBox(), 0, 1, false), 2, 0, 1, 1, 0, 0, false)
 
 	app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		shift := event.Modifiers()&tcell.ModShift != 0
 		switch key := event.Key(); key {
-		case tcell.KeyEscape:
-			app.Stop()
 		case tcell.KeyCtrlN:
 			return tcell.NewEventKey(tcell.KeyDown, ' ', tcell.ModNone)
 		case tcell.KeyCtrlP:


### PR DESCRIPTION
Another one; this feature adds an error view displaying jq's error message.  They're usually not that informative, but still can be of some use when putting a filter expression together.

Reverts the Escape key change so that Escape can be used for dismissing the autocomplete menu if need be.