### PR TITLE
Add option and keybind to toggle input viewing pane

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module codeberg.org/gpanders/ijq
 
-go 1.18
+go 1.20
 
 require (
 	github.com/gdamore/tcell/v2 v2.7.1

--- a/ijq.1.scd
+++ b/ijq.1.scd
@@ -61,6 +61,13 @@ All of the options mirror their counterparts in *jq*. The options are:
 	Specify the path to store history. If set to '' (-H ''), then history
 	will not be captured.
 
+*ijq* has some options that influence its starting layout. They are designed to
+avoid conflicts with *jq*. If *jq* adds in the future adds an option that
+conflicts with one of these, they might change here.
+
+*-O*
+	Hides the input (left) viewing pane, which shows the original input.
+
 # KEY BINDINGS
 
 *Shift + Up*, *Shift + Left*

--- a/ijq.1.scd
+++ b/ijq.1.scd
@@ -108,6 +108,9 @@ All of the options mirror their counterparts in *jq*. The options are:
 	cursor to the beginning of the field. When one of the viewing panes has
 	focus, scroll up one half page.
 
+*Ctrl-O*
+	Toggle visibility of the input (left) viewing pane.
+
 *u*, *d*, *f*, *b*
 	When one of the viewing panes has focus, scroll a half/full page
 	up/down.

--- a/ijq.1.scd
+++ b/ijq.1.scd
@@ -57,13 +57,13 @@ All of the options mirror their counterparts in *jq*. The options are:
 	Read the filter from _file_. When this option is used, all positional
 	arguments (if any) are interpreted as input files.
 
+*ijq* has some options that influence its configuration and starting layout.
+They are designed to avoid conflicts with *jq*. If *jq* adds in the future
+adds an option that conflicts with one of these, they might change here.
+
 *-H* _file_
 	Specify the path to store history. If set to '' (-H ''), then history
 	will not be captured.
-
-*ijq* has some options that influence its starting layout. They are designed to
-avoid conflicts with *jq*. If *jq* adds in the future adds an option that
-conflicts with one of these, they might change here.
 
 *-hide-input-pane*
 	Hides the input (left) viewing pane, which shows the original input.

--- a/ijq.1.scd
+++ b/ijq.1.scd
@@ -65,7 +65,7 @@ All of the options mirror their counterparts in *jq*. The options are:
 avoid conflicts with *jq*. If *jq* adds in the future adds an option that
 conflicts with one of these, they might change here.
 
-*-O*
+*-hide-input-pane*
 	Hides the input (left) viewing pane, which shows the original input.
 
 # KEY BINDINGS

--- a/main.go
+++ b/main.go
@@ -186,7 +186,7 @@ func parseArgs() (Options, string, []string) {
 	flag.BoolVar(&options.forceColor, "C", false, "force colorized JSON, even if writing to a pipe or file")
 	flag.BoolVar(&options.monochrome, "M", false, "monochrome (don't colorize JSON)")
 	flag.BoolVar(&options.sortKeys, "S", false, "sort keys of objects on output")
-	flag.BoolVar(&options.hideInputPane, "O", false, "hide input (left) viewing pane")
+	flag.BoolVar(&options.hideInputPane, "hide-input-pane", false, "hide input (left) viewing pane")
 
 	flag.StringVar(
 		&options.command,

--- a/main.go
+++ b/main.go
@@ -49,16 +49,17 @@ const alphabet string = "abcdefghijklmnopqrstuvwxyz"
 var Version string
 
 type Options struct {
-	compact     bool
-	command     string
-	nullInput   bool
-	slurp       bool
-	rawOutput   bool
-	rawInput    bool
-	monochrome  bool
-	sortKeys    bool
-	historyFile string
-	forceColor  bool
+	compact       bool
+	command       string
+	nullInput     bool
+	slurp         bool
+	rawOutput     bool
+	rawInput      bool
+	monochrome    bool
+	sortKeys      bool
+	historyFile   string
+	forceColor    bool
+	hideInputPane bool
 }
 
 // Convert the Options struct to a string slice of option flags that gets
@@ -185,6 +186,7 @@ func parseArgs() (Options, string, []string) {
 	flag.BoolVar(&options.forceColor, "C", false, "force colorized JSON, even if writing to a pipe or file")
 	flag.BoolVar(&options.monochrome, "M", false, "monochrome (don't colorize JSON)")
 	flag.BoolVar(&options.sortKeys, "S", false, "sort keys of objects on output")
+	flag.BoolVar(&options.hideInputPane, "O", false, "hide input (left) viewing pane")
 
 	flag.StringVar(
 		&options.command,
@@ -304,7 +306,7 @@ func createApp(doc Document) *tview.Application {
 	inputView := tview.NewTextView()
 	inputView.SetDynamicColors(true).SetWrap(false).SetBorder(true)
 	inputPane := pane{tv: inputView}
-	isInputPaneHidden := false
+	isInputPaneHidden := doc.options.hideInputPane
 
 	outputView := tview.NewTextView()
 	outputView.SetDynamicColors(true).SetWrap(false).SetBorder(true)
@@ -498,8 +500,12 @@ func createApp(doc Document) *tview.Application {
 		}
 	}()
 
+	inputPaneProportion := 1
+	if isInputPaneHidden {
+		inputPaneProportion = 0
+	}
 	viewFlex := tview.NewFlex().
-		AddItem(inputView, 0, 1, false).
+		AddItem(inputView, 0, inputPaneProportion, false).
 		AddItem(outputView, 0, 1, false)
 	grid := tview.NewGrid().
 		SetRows(0, 3, 4).


### PR DESCRIPTION
Hi @gpanders,

I took a stab at #13 (and bumped the go version to 1.20, as explained in #14).

This PR implements an option, `-hide-input-pane`, which hides the input viewing pane on startup. It also implement the keybind `Ctrl-O` while the repl is active, which toggles the input viewing pane. Both are documented in the man page and the option is documented in the usage text.

Toggling the input viewing pane while it is focussed, moves the focus to the output viewing pane. The input viewing pane can not be focussed while it is hidden.

---

When implementing this I was thinking through a few things:

**How to hide the input pane**
The options I considered are:
- Setting the flex proportion to zero (current implementation). This seemed like an elegant solution to me, since it does not change the app's structure at all.
- Removing the pane from the flex and re-adding it. This did not work, since adding an item to a flex only adds it to the back. We could remove the output pane also and re-add both, but that seems wasteful.

**Is hiding a pane something that is relevant for panes other than the input pane?**
I've asked myself this question to determine how abstract the logic should be implemented. After a few iterations of how hiding a pane could be implemented in an abstract way, I realized, that no way really works. Hiding a pane is dependent on where in the grid it is and on what else around it is visible. Hiding the input and output panes could be abstracted, but the logic for the input and error panes would be very different. So I decided to explicitly implement this only for the input pane.
At first I implemented the `isInputPaneHidden` variable as a field of `pane` but later decided to make it stand for itself. Also I don't think any of the other panes will ever need to be hidden, since they are integral for the interactive nature of ijq.

**What key-combination makes most sense for toggling the input pane?**
My first instinct was Ctrl-O, to be in line with the other Ctrl-based key-combinations and "O" for "original". I thought about Meta-O to distinguish the layout action from movement actions. I frankly decided against it because checking for a Meta/Alt Mod with tcell seemed more complicated than appropriate.
At some point I considered Ctrl-I, with "I" for "input", but quickly realized that for some reason Ctrl-I and KeyTab have identical values, which made this impossible :exploding_head: If you have a solution for this, I think I would prefer Ctrl-I.
No other applications with a similar layout and key-combination come to mind. Do you have another suggestion?

**Other considerations**
I changed quite a bit regarding focus behavior. Not focussing the hidden input view is a must, I think. But having Shift+Up focus the output view or even preventing focussing the input view are not strictly necessary. I could remove those again, if you think less change is better.

I also took some liberties while extending the man page. You might want to rewrite the section about option conflicts with ijq :)

---

If there's any changes you'd like me to make, please ask :)
yeldiR